### PR TITLE
update handler to take queue_class and client_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Or install it yourself as:
 # config/application.rb
 config.middleware.use(Tracker::Middleware) do
   # register handlers
-  handler Tracker::GoogleAnalytics, { api_key: "" }
+  handler(
+    queue_class:  Tracker::GoogleAnalytics::Queuer,
+    client_class: Tracker::GoogleAnalytics::Client,
+    opts:         { api_key: "" }
+  )
+
   handler Tracker::Handlers::Ahoy, { api_key: "" }
 
   # TODO

--- a/lib/tracker.rb
+++ b/lib/tracker.rb
@@ -4,10 +4,10 @@ require_relative "tracker/middleware"
 require_relative "tracker/controller"
 require_relative "tracker/handlers"
 require_relative "tracker/background"
-require_relative "tracker/railtie"
+require_relative "tracker/railtie" if defined?(Rails)
 
 module Tracker
-  GoogleAnalytics = Handlers::GoogleAnalytics::Queuer
+  GoogleAnalytics = Handlers::GoogleAnalytics
 
   class NotImplemented < StandardError; end
 end

--- a/lib/tracker/controller.rb
+++ b/lib/tracker/controller.rb
@@ -3,9 +3,12 @@ module Tracker::Controller
 
   def queue_tracker(&blk)
     if (t = env[Tracker::Middleware::KEY]; t)
-      t.handlers.each do |h|
+      t.handlers.each do |handler|
         t.queuer.queue(
-          blk.call(h.klass.new(h.opts.merge(env: env, uuid_fetcher: t.uuid)))
+          handler.client_class.to_s,
+          blk.call(
+            handler.queuer_class.new(handler.opts.merge(env: env, uuid_fetcher: t.uuid))
+          )
         )
       end
     end

--- a/lib/tracker/middleware.rb
+++ b/lib/tracker/middleware.rb
@@ -1,5 +1,5 @@
 module Tracker
-  DeferedInitializer = Struct.new(:klass, :opts)
+  DeferedInitializer = Struct.new(:queuer_class, :client_class, :opts)
 
   class Middleware
     attr_reader :app, :handlers
@@ -18,8 +18,8 @@ module Tracker
       app.call(env)
     end
 
-    def handler(klass, opts={})
-      @handlers << DeferedInitializer.new(klass, opts)
+    def handler(queue_class:, client_class:, opts: {})
+      @handlers << DeferedInitializer.new(queue_class, client_class, opts)
     end
 
     def queuer(q=nil)

--- a/spec/lib/tracker/middleware_spec.rb
+++ b/spec/lib/tracker/middleware_spec.rb
@@ -4,7 +4,11 @@ describe Tracker do
   def app
     Rack::Builder.new do
       use Tracker::Middleware do
-        handler Tracker::GoogleAnalytics, { api_key: "" }
+        handler(
+          queue_class:  Tracker::GoogleAnalytics::Queuer,
+          client_class: Tracker::GoogleAnalytics::Client,
+          opts:         { api_key: "" }
+        )
 
         queuer "QueurClassName"
         uuid do |env|


### PR DESCRIPTION
queue_class is used in controller during request to queue page/event class to background workre like sidekiq which will use client_class to send queued calls to external services in background worker