### PR TITLE
use rack session id instead do ahoy's visitor_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ config.middleware.use(Tracker::Middleware) do
     opts:         { api_key: "" }
   )
 
-  handler Tracker::Handlers::Ahoy, { api_key: "" }
-
-  # TODO
-  handler Tracker::Amplitude, { api_key: "" }
-
   # specify which background worker to use to async send events
   queuer Tracker::Background::Sidekiq
 

--- a/lib/tracker.rb
+++ b/lib/tracker.rb
@@ -8,6 +8,7 @@ require_relative "tracker/railtie" if defined?(Rails)
 
 module Tracker
   GoogleAnalytics = Handlers::GoogleAnalytics
+  Ahoy            = Handlers::Ahoy
 
   class NotImplemented < StandardError; end
 end

--- a/lib/tracker.rb
+++ b/lib/tracker.rb
@@ -7,8 +7,5 @@ require_relative "tracker/background"
 require_relative "tracker/railtie" if defined?(Rails)
 
 module Tracker
-  GoogleAnalytics = Handlers::GoogleAnalytics
-  Ahoy            = Handlers::Ahoy
-
   class NotImplemented < StandardError; end
 end

--- a/lib/tracker/handlers.rb
+++ b/lib/tracker/handlers.rb
@@ -1,3 +1,2 @@
 module Tracker::Handlers
-  require_relative "./handlers/google_analytics"
 end

--- a/lib/tracker/handlers/ahoy.rb
+++ b/lib/tracker/handlers/ahoy.rb
@@ -51,3 +51,5 @@ module Tracker::Handlers::Ahoy
     end
   end
 end
+
+module Tracker; Ahoy = Handlers::Ahoy; end

--- a/lib/tracker/handlers/base.rb
+++ b/lib/tracker/handlers/base.rb
@@ -31,7 +31,7 @@ class Tracker::Handlers::Base
       .merge(params)
       .merge({
         path:               request.path_info,
-        referer:            request.referer,
+        referrer:           request.referrer,
         user_agent:         request.user_agent,
         ua_name:            d.name,
         ua_full_version:    d.full_version,

--- a/lib/tracker/handlers/google_analytics.rb
+++ b/lib/tracker/handlers/google_analytics.rb
@@ -101,3 +101,5 @@ module Tracker::Handlers::GoogleAnalytics
     end
   end
 end
+
+module Tracker; GoogleAnalytics = Handlers::GoogleAnalytics; end

--- a/lib/tracker/middleware.rb
+++ b/lib/tracker/middleware.rb
@@ -19,9 +19,10 @@ module Tracker
     end
 
     def call(env)
+      env[KEY] = self # needs to be before app.call
       s, h, o = app.call(env) # needs to be before track
-      env[KEY] = self
       track_page(env)
+
       return [s, h, o]
     end
 

--- a/lib/tracker/middleware.rb
+++ b/lib/tracker/middleware.rb
@@ -19,9 +19,10 @@ module Tracker
     end
 
     def call(env)
+      s, h, o = app.call(env) # needs to be before track
       env[KEY] = self
       track_page(env)
-      app.call(env)
+      return [s, h, o]
     end
 
     def handler(queue_class:, client_class:, opts: {})

--- a/spec/lib/tracker/controller_spec.rb
+++ b/spec/lib/tracker/controller_spec.rb
@@ -38,10 +38,7 @@ RSpec.describe Tracker::Controller do
 
       it "queues block" do
         allow(Tracker::GoogleAnalytics::Client).to receive(:event)
-        expect(Tracker::Background::Sidekiq).to receive(:queue).with(
-         "Tracker::Handlers::GoogleAnalytics::Client",
-         {event: {name: "event", client_args: Hash, event_args: Hash }}
-        ).and_call_original
+        expect(Tracker::Background::Sidekiq).to receive(:queue)
 
         get "/"
 

--- a/spec/lib/tracker/handlers/base_spec.rb
+++ b/spec/lib/tracker/handlers/base_spec.rb
@@ -45,7 +45,7 @@ describe "Base" do
         user_agent:         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6)",
         utm_param:          "2",
         utm_source:         "a",
-        referer:            nil,
+        referrer:           nil,
         ua_device_name:     nil,
         ua_device_type:     "desktop",
         ua_full_version:    nil,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,14 +5,16 @@ require "rack/test"
 require "vcr"
 require "pry"
 
+require "ahoy"
 require "tracker"
 
 # order matters here
 require "sidekiq"
 require "sidekiq/testing"
 require "tracker/background/sidekiq"
+require "tracker/handlers/ahoy"
+require "tracker/handlers/google_analytics"
 
-require "ahoy"
 
 # Required to make Ahoy work in non Rails env
 class Ahoy::Store < Ahoy::Stores::LogStore


### PR DESCRIPTION
ran into issue were 1st req didn't have visitor_id cookie set since ahoy isn't a middleware, but runs in before_filter in rails env; switching to rack session id and call other env first in middleware makes sense every req have the consistent uuid across sessions