### PR TITLE
use httparty to post to amplitude

### DIFF
--- a/lib/tracker/handlers/amplitude.rb
+++ b/lib/tracker/handlers/amplitude.rb
@@ -1,4 +1,5 @@
 require_relative "./base"
+require "httparty"
 
 module Tracker::Handlers::Amplitude
   class Queuer < Tracker::Handlers::Base
@@ -12,9 +13,8 @@ module Tracker::Handlers::Amplitude
     def page(path:, page_args: {})
       {
         track: {
-          name:       Tracker::VISITED_PAGE,
           api_key:    api_key,
-          event_args: build_event_args(page_args).merge({path: path})
+          event_args: build_event_args(Tracker::VISITED_PAGE, page_args.merge(path: path))
         }
       }
     end
@@ -28,19 +28,19 @@ module Tracker::Handlers::Amplitude
     def event(name:, event_args: {})
       {
         track: {
-          name:       name,
           api_key:    api_key,
-          event_args: build_event_args(event_args)
+          event_args: build_event_args(name, event_args)
         }
       }
     end
 
     private
 
-    def build_event_args(args)
+    def build_event_args(name, args)
       {
         user_id:          args[:user_id],
         device_id:        uuid,
+        event_type:       name,
         event_properties: args,
         insert_id:        SecureRandom.base64,
         time:             DateTime.now.strftime('%Q')
@@ -50,17 +50,10 @@ module Tracker::Handlers::Amplitude
 
   class Client
     class << self
-      def track(name:, api_key:, event_args: {})
-        set_api_key(api_key)
-        AmplitudeAPI.track(AmplitudeAPI::Event.new(event_args))
-      end
+      URL = "https://api.amplitude.com/httpapi".freeze
 
-      private
-
-      # Accepts:
-      #   api_key - String
-      def set_api_key(api_key)
-        AmplitudeAPI.api_key = api_key
+      def track(api_key:, event_args: {})
+        HTTParty.post(URL, {body: {api_key: api_key, event: JSON.dump(event_args)}})
       end
     end
   end

--- a/lib/tracker/handlers/amplitude.rb
+++ b/lib/tracker/handlers/amplitude.rb
@@ -38,10 +38,10 @@ module Tracker::Handlers::Amplitude
 
     def build_event_args(name, args)
       {
-        user_id:          args[:user_id],
+        user_id:          args[:user_id] || user_id_from_session,
         device_id:        uuid,
         event_type:       name,
-        event_properties: args,
+        event_properties: default_args.merge(args),
         insert_id:        SecureRandom.base64,
         time:             DateTime.now.strftime('%Q')
       }

--- a/lib/tracker/handlers/base.rb
+++ b/lib/tracker/handlers/base.rb
@@ -53,8 +53,12 @@ class Tracker::Handlers::Base
   def default_args
     {
       uuid:      uuid,
-      user_id:   request.session["user_id"],
+      user_id:   user_id_from_session,
       host_name: request.env["HTTP_HOST"]
     }
+  end
+
+  def user_id_from_session
+    request.session["user_id"]
   end
 end

--- a/spec/lib/tracker/handlers/amplitude_spec.rb
+++ b/spec/lib/tracker/handlers/amplitude_spec.rb
@@ -13,14 +13,13 @@ describe "Amplitude" do
     it "builds pageview with given and default args" do
       expect(queuer.page(path: "/", page_args: {a: 1})).to include({
         track: {
-          name:       "Visited page",
           api_key:    "api_key",
           event_args: hash_including(
             device_id: "uuid",
-            path:      "/",
             insert_id: String,
             time:      String,
-            event_properties: {a: 1}
+            event_type: "Visited page",
+            event_properties: {a: 1, path: "/"}
           )
         }
       })
@@ -29,9 +28,9 @@ describe "Amplitude" do
     it "builds event with given and default args" do
       expect(queuer.event(name: "event name", event_args: {a: 1})).to include({
         track: {
-          name:    "event name",
           api_key: "api_key",
           event_args: hash_including(
+            event_type: "event name",
             event_properties: {a: 1}
           )
         }
@@ -43,7 +42,7 @@ describe "Amplitude" do
     subject { Tracker::Handlers::Amplitude::Client }
 
     it "sets client api key" do
-      expect(AmplitudeAPI).to receive(:api_key=).with("api_key")
+      expect(HTTParty).to receive(:post)
 
       subject.track(queuer.page(path: "/", page_args: {a: 1})[:track])
     end

--- a/spec/lib/tracker/handlers/amplitude_spec.rb
+++ b/spec/lib/tracker/handlers/amplitude_spec.rb
@@ -19,7 +19,7 @@ describe "Amplitude" do
             insert_id: String,
             time:      String,
             event_type: "Visited page",
-            event_properties: {a: 1, path: "/"}
+            event_properties: hash_including(a: 1, path: "/")
           )
         }
       })
@@ -31,7 +31,7 @@ describe "Amplitude" do
           api_key: "api_key",
           event_args: hash_including(
             event_type: "event name",
-            event_properties: {a: 1}
+            event_properties: hash_including(a: 1)
           )
         }
       })

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "vcr"
 require "pry"
 
 require "ahoy"
-require "amplitude-api"
+require "staccato"
 
 require "tracker"
 

--- a/tracker.gemspec
+++ b/tracker.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "staccato", ">= 0.5"
   spec.add_dependency "activesupport", "~> 4.0.13"
   spec.add_dependency "device_detector"
+  spec.add_dependency "httparty"
 
   spec.add_development_dependency "rack", ">= 1.0"
   spec.add_development_dependency "bundler"
@@ -29,11 +29,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "actionpack", "~> 4.0.13"
-
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sidekiq", "~> 2.4.0"
   spec.add_development_dependency "rspec-sidekiq"
   spec.add_development_dependency "vcr"
+
   spec.add_development_dependency "ahoy_matey"
-  spec.add_development_dependency "amplitude-api"
+  spec.add_development_dependency "staccato", ">= 0.5"
 end


### PR DESCRIPTION
amplidude-api was using a version of typeous that conflicted with goatee's prexisting version, hence the move to HTTParty